### PR TITLE
feat: 添加实时资源使用指标并重构资源使用计算逻辑

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -72,9 +72,13 @@ func StreamExample() {
 func PodUsageExample() {
 	podName := "coredns-ccb96694c-jprpf"
 	ns := "kube-system"
-	usage := kom.DefaultCluster().Resource(&corev1.Pod{}).
+	usage, err := kom.DefaultCluster().Resource(&corev1.Pod{}).
 		Name(podName).Namespace(ns).
 		Ctl().Pod().ResourceUsageTable()
+	if err != nil {
+		fmt.Printf("Get pod usage error %v\n", err.Error())
+		return
+	}
 	fmt.Printf("Pod Usage %s\n", utils.ToJSON(usage))
 
 }
@@ -91,8 +95,12 @@ func ALLNodeUsageExample() {
 	}
 	for i := range nodeList {
 		nodeName := nodeList[i].Name
-		usage := kom.DefaultCluster().Resource(&corev1.Node{}).
+		usage, err := kom.DefaultCluster().Resource(&corev1.Node{}).
 			Name(nodeName).WithCache(5 * time.Second).Ctl().Node().ResourceUsageTable()
+		if err != nil {
+			fmt.Printf(err.Error())
+			return
+		}
 		fmt.Printf("Node Usage %s\n", utils.ToJSON(usage))
 	}
 

--- a/example/metrics_test.go
+++ b/example/metrics_test.go
@@ -1,0 +1,40 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/weibaohui/kom/kom"
+	"github.com/weibaohui/kom/utils"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestPrintPodMetrics(t *testing.T) {
+
+	result, err := kom.DefaultCluster().
+		Resource(&v1.Pod{}).
+		Namespace("kube-system").
+		Name("kube-apiserver-kind-cluster-control-plane").
+		Ctl().Pod().ResourceUsageTable()
+
+	if err != nil {
+		t.Logf(err.Error())
+	}
+
+	t.Logf("\n%s\n", utils.ToJSON(result))
+
+}
+
+func TestPrintNodeMetrics(t *testing.T) {
+
+	result, err := kom.DefaultCluster().
+		Resource(&v1.Node{}).
+		Name("kind-cluster-control-plane").
+		Ctl().Node().ResourceUsageTable()
+
+	if err != nil {
+		t.Logf(err.Error())
+	}
+
+	t.Logf("\n%s\n", utils.ToJSON(result))
+
+}

--- a/example/node_usage_test.go
+++ b/example/node_usage_test.go
@@ -1,6 +1,7 @@
 package example
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,8 +27,12 @@ func TestNodeResourceUsageTable(t *testing.T) {
 	// 打印开始时间
 	startTime := time.Now()
 	nodeName := "kind-control-plane"
-	usage := kom.DefaultCluster().Resource(&corev1.Node{}).
+	usage, err := kom.DefaultCluster().Resource(&corev1.Node{}).
 		Name(nodeName).WithCache(5 * time.Second).Ctl().Node().ResourceUsageTable()
+	if err != nil {
+		fmt.Printf(err.Error())
+		return
+	}
 	t.Logf("Node Usage %s\n", utils.ToJSON(usage))
 	// 打印结束时间
 	endTime := time.Now()

--- a/kom/ctl_node_usage.go
+++ b/kom/ctl_node_usage.go
@@ -1,0 +1,215 @@
+package kom
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/weibaohui/kom/utils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+	resourcehelper "k8s.io/kubectl/pkg/util/resource"
+)
+
+// NodeUsage 表示容器资源使用情况
+type NodeUsage struct {
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+func (d *node) TotalRequestsAndLimits() (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {
+	pods, err := d.RunningPods()
+	if err != nil {
+		klog.V(6).Infof("Get TotalRequestsAndLimits in node/%s  error %v\n", d.kubectl.Statement.Name, err.Error())
+		return nil, nil
+	}
+	return getPodsTotalRequestsAndLimits(pods)
+}
+
+// ResourceUsage 获取节点的资源使用情况，包括资源的请求和限制，还有当前使用占比
+func (d *node) ResourceUsage() (*ResourceUsageResult, error) {
+
+	// 计算实时值
+	realtimeMetrics := make(map[v1.ResourceName]resource.Quantity)
+
+	if metrics, err := d.Metrics(); err == nil {
+		cpu := metrics.CPU
+		if cpu != "" {
+			if cpuQty, err := resource.ParseQuantity(cpu); err == nil {
+				realtimeMetrics[v1.ResourceCPU] = cpuQty
+			}
+		}
+		memory := metrics.Memory
+		if memory != "" {
+			if memQty, err := resource.ParseQuantity(memory); err == nil {
+				realtimeMetrics[v1.ResourceMemory] = memQty
+			}
+		}
+
+	}
+
+	reqs, limits := d.TotalRequestsAndLimits()
+	if reqs == nil || limits == nil {
+		return nil, fmt.Errorf("getPodsTotalRequestsAndLimits error")
+	}
+	cacheTime := d.getCacheTTL()
+	n, err := d.getNodeWithCache(cacheTime)
+	if err != nil {
+		klog.V(6).Infof("Get ResourceUsage in node/%s  error %v\n", d.kubectl.Statement.Name, err.Error())
+		return nil, err
+	}
+
+	allocatable := n.Status.Capacity
+	if len(n.Status.Allocatable) > 0 {
+		allocatable = n.Status.Allocatable
+	}
+
+	klog.V(8).Infof("allocatable=:\n%s", utils.ToJSON(allocatable))
+	cpuReqs, cpuLimits, memoryReqs, memoryLimits, ephemeralstorageReqs, ephemeralstorageLimits :=
+		reqs[corev1.ResourceCPU], limits[corev1.ResourceCPU], reqs[corev1.ResourceMemory], limits[corev1.ResourceMemory], reqs[corev1.ResourceEphemeralStorage], limits[corev1.ResourceEphemeralStorage]
+	cpuRealtime, memoryRealtime := realtimeMetrics[corev1.ResourceCPU], realtimeMetrics[corev1.ResourceMemory]
+
+	// 计算CPU 使用率
+	fractionCpuReqs := float64(0)
+	fractionCpuLimits := float64(0)
+	fractionCpuRealtime := float64(0)
+	if allocatable.Cpu().MilliValue() != 0 {
+		fractionCpuReqs = float64(cpuReqs.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+		fractionCpuLimits = float64(cpuLimits.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+		fractionCpuRealtime = float64(cpuRealtime.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+	}
+
+	// 计算内存 使用率
+	fractionMemoryReqs := float64(0)
+	fractionMemoryLimits := float64(0)
+	fractionMemoryRealtime := float64(0)
+	if allocatable.Memory().Value() != 0 {
+		fractionMemoryReqs = float64(memoryReqs.Value()) / float64(allocatable.Memory().Value()) * 100
+		fractionMemoryLimits = float64(memoryLimits.Value()) / float64(allocatable.Memory().Value()) * 100
+		fractionMemoryRealtime = float64(memoryRealtime.Value()) / float64(allocatable.Memory().Value()) * 100
+	}
+
+	// 计算存储 使用率
+	fractionEphemeralStorageReqs := float64(0)
+	fractionEphemeralStorageLimits := float64(0)
+	if allocatable.StorageEphemeral().Value() != 0 {
+		fractionEphemeralStorageReqs = float64(ephemeralstorageReqs.Value()) / float64(allocatable.StorageEphemeral().Value()) * 100
+		fractionEphemeralStorageLimits = float64(ephemeralstorageLimits.Value()) / float64(allocatable.StorageEphemeral().Value()) * 100
+	}
+
+	usageFractions := map[corev1.ResourceName]ResourceUsageFraction{
+		corev1.ResourceCPU: {
+			RequestFraction:  fractionCpuReqs,
+			LimitFraction:    fractionCpuLimits,
+			RealtimeFraction: fractionCpuRealtime,
+		},
+		corev1.ResourceMemory: {
+			RequestFraction:  fractionMemoryReqs,
+			LimitFraction:    fractionMemoryLimits,
+			RealtimeFraction: fractionMemoryRealtime,
+		},
+		corev1.ResourceEphemeralStorage: {
+			RequestFraction: fractionEphemeralStorageReqs,
+			LimitFraction:   fractionEphemeralStorageLimits,
+		},
+	}
+	klog.V(6).Infof("node/%s resource usage\n", d.kubectl.Statement.Name)
+	klog.V(6).Infof("%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceCPU, cpuReqs.String(), int64(fractionCpuReqs), cpuLimits.String(), int64(fractionCpuLimits))
+	klog.V(6).Infof("%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceMemory, memoryReqs.String(), int64(fractionMemoryReqs), memoryLimits.String(), int64(fractionMemoryLimits))
+	klog.V(6).Infof("%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceEphemeralStorage, ephemeralstorageReqs.String(), int64(fractionEphemeralStorageReqs), ephemeralstorageLimits.String(), int64(fractionEphemeralStorageLimits))
+
+	return &ResourceUsageResult{
+		Requests:       reqs,
+		Limits:         limits,
+		Realtime:       realtimeMetrics,
+		Allocatable:    allocatable,
+		UsageFractions: usageFractions,
+	}, nil
+}
+func (d *node) ResourceUsageTable() ([]*ResourceUsageRow, error) {
+	usage, err := d.ResourceUsage()
+	if err != nil {
+		return nil, err
+	}
+	data, err := convertToTableData(usage)
+	if err != nil {
+		klog.V(6).Infof("convertToTableData error %v\n", err.Error())
+		return nil, err
+	}
+	return data, nil
+}
+
+func getPodsTotalRequestsAndLimits(podList []*corev1.Pod) (reqs map[corev1.ResourceName]resource.Quantity, limits map[corev1.ResourceName]resource.Quantity) {
+	reqs, limits = map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
+	for _, pod := range podList {
+		podReqs, podLimits := resourcehelper.PodRequestsAndLimits(pod)
+		for podReqName, podReqValue := range podReqs {
+			if value, ok := reqs[podReqName]; !ok {
+				reqs[podReqName] = podReqValue.DeepCopy()
+			} else {
+				value.Add(podReqValue)
+				reqs[podReqName] = value
+			}
+		}
+		for podLimitName, podLimitValue := range podLimits {
+			if value, ok := limits[podLimitName]; !ok {
+				limits[podLimitName] = podLimitValue.DeepCopy()
+			} else {
+				value.Add(podLimitValue)
+				limits[podLimitName] = value
+			}
+		}
+	}
+	return
+}
+
+func (d *node) Metrics() (*NodeUsage, error) {
+
+	var inst *unstructured.Unstructured
+	stmt := d.kubectl.Statement
+	cacheTime := stmt.CacheTTL
+	if cacheTime == 0 {
+		cacheTime = 5 * time.Second
+	}
+	err := d.kubectl.newInstance().
+		WithContext(stmt.Context).
+		CRD("metrics.k8s.io", "v1beta1", "NodeMetrics").
+		Name(stmt.Name).
+		WithCache(cacheTime).
+		Get(&inst).Error
+	if err != nil {
+		klog.V(6).Infof("Get ResourceUsage in Node/%s  error %v\n", stmt.Name, err.Error())
+		// 可能Metrics-Server 没有安装
+		return nil, err
+	}
+	klog.V(6).Infof("inst = %s", inst)
+	usage, err := ExtractNodeMetrics(inst)
+	if err != nil {
+		return nil, err
+	}
+
+	return usage, nil
+}
+
+// ExtractNodeMetrics 提取 containers 字段，返回标准结构
+func ExtractNodeMetrics(u *unstructured.Unstructured) (*NodeUsage, error) {
+	usageRaw, found, err := unstructured.NestedMap(u.Object, "usage")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract containers: %v", err)
+	}
+	if !found {
+		return nil, fmt.Errorf("containers not found in object")
+	}
+	klog.V(6).Infof("usageraw %s", usageRaw)
+	nodeUsage := &NodeUsage{
+		CPU:    usageRaw[corev1.ResourceCPU.String()].(string),
+		Memory: usageRaw[corev1.ResourceMemory.String()].(string),
+	}
+	klog.V(6).Infof("node/%s resource usage\n", utils.ToJSON(nodeUsage))
+	return nodeUsage, nil
+}

--- a/kom/ctl_pod_usage.go
+++ b/kom/ctl_pod_usage.go
@@ -1,16 +1,136 @@
 package kom
 
 import (
+	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/weibaohui/kom/utils"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	resourcehelper "k8s.io/kubectl/pkg/util/resource"
 )
 
+// ContainerUsage 表示容器资源使用情况
+type ContainerUsage struct {
+	CPU    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+// PodMetrics 表示容器指标数据
+type PodMetrics struct {
+	Name  string         `json:"name"`
+	Usage ContainerUsage `json:"usage"`
+}
+
+func (p *pod) Metrics() ([]PodMetrics, error) {
+
+	var inst unstructured.Unstructured
+	stmt := p.kubectl.Statement
+	cacheTime := stmt.CacheTTL
+	containerName := stmt.ContainerName
+	if cacheTime == 0 {
+		cacheTime = 5 * time.Second
+	}
+	err := p.kubectl.newInstance().
+		WithContext(stmt.Context).
+		CRD("metrics.k8s.io", "v1beta1", "PodMetrics").
+		Namespace(stmt.Namespace).
+		Name(stmt.Name).
+		WithCache(cacheTime).
+		Get(&inst).Error
+	if err != nil {
+		klog.V(6).Infof("Get ResourceUsage in pod/%s  error %v\n", stmt.Name, err.Error())
+		// 可能Metrics-Server 没有安装
+		return nil, err
+	}
+
+	containers, err := ExtractPodMetrics(&inst, containerName)
+	if err != nil {
+		return nil, err
+	}
+
+	return containers, nil
+}
+
+// ExtractPodMetrics 提取 containers 字段，返回标准结构
+func ExtractPodMetrics(u *unstructured.Unstructured, containerName string) ([]PodMetrics, error) {
+	containersRaw, found, err := unstructured.NestedSlice(u.Object, "containers")
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract containers: %v", err)
+	}
+	if !found {
+		return nil, fmt.Errorf("containers not found in object")
+	}
+
+	var result []PodMetrics
+	cpuTotal := big.NewInt(0)
+	memTotal := big.NewInt(0)
+
+	for _, c := range containersRaw {
+		containerMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if containerName != "" && containerMap["name"] != containerName {
+			continue
+		}
+
+		containerMetric := PodMetrics{
+			Name:  containerMap["name"].(string),
+			Usage: ContainerUsage{},
+		}
+
+		if usage, ok := containerMap["usage"].(map[string]interface{}); ok {
+			if cpuStr, ok := usage["cpu"].(string); ok {
+				containerMetric.Usage.CPU = cpuStr
+			}
+			if memStr, ok := usage["memory"].(string); ok {
+				containerMetric.Usage.Memory = memStr
+			}
+		}
+
+		result = append(result, containerMetric)
+
+		usage, ok := containerMap["usage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if cpuStr, ok := usage["cpu"].(string); ok {
+			cpuQty := resource.MustParse(cpuStr)
+			cpuTotal.Add(cpuTotal, cpuQty.AsDec().UnscaledBig())
+		}
+
+		if memStr, ok := usage["memory"].(string); ok {
+			memQty := resource.MustParse(memStr)
+			memTotal.Add(memTotal, memQty.AsDec().UnscaledBig())
+		}
+	}
+
+	// 计算成 float64 形式（CPU: m核；内存: Mi）
+	cpuMilli := new(big.Float).Quo(new(big.Float).SetInt(cpuTotal), big.NewFloat(1_000_000))
+	memMi := new(big.Float).Quo(new(big.Float).SetInt(memTotal), big.NewFloat(1024*1024))
+
+	// 格式化字符串形式
+	cpuFormatted, _ := cpuMilli.Float64()
+	memFormatted, _ := memMi.Float64()
+
+	result = append(result, PodMetrics{
+		Name: "total",
+		Usage: ContainerUsage{
+			CPU:    fmt.Sprintf("%.0fm", cpuFormatted),  // 毫核
+			Memory: fmt.Sprintf("%.0fMi", memFormatted), // MiB
+		},
+	})
+
+	return result, nil
+}
+
 // ResourceUsage 获取节点的资源使用情况，包括资源的请求和限制，还有当前使用占比
-func (p *pod) ResourceUsage() *ResourceUsageResult {
+func (p *pod) ResourceUsage() (*ResourceUsageResult, error) {
 
 	var inst *v1.Pod
 	cacheTime := p.kubectl.Statement.CacheTTL
@@ -18,6 +138,25 @@ func (p *pod) ResourceUsage() *ResourceUsageResult {
 		cacheTime = 5 * time.Second
 	}
 	klog.V(6).Infof("Pod ResourceUsage cacheTime %v\n", cacheTime)
+
+	// 计算实时值
+	realtimeMetrics := make(map[v1.ResourceName]resource.Quantity)
+
+	if podMetrics, err := p.Metrics(); err == nil {
+		for _, metric := range podMetrics {
+			if metric.Name != "total" {
+				continue
+			}
+			if cpuQty, err := resource.ParseQuantity(metric.Usage.CPU); err == nil {
+				realtimeMetrics[v1.ResourceCPU] = cpuQty
+			}
+			if memQty, err := resource.ParseQuantity(metric.Usage.Memory); err == nil {
+				realtimeMetrics[v1.ResourceMemory] = memQty
+			}
+
+		}
+	}
+
 	err := p.kubectl.newInstance().WithContext(p.kubectl.Statement.Context).Resource(&v1.Pod{}).
 		Namespace(p.kubectl.Statement.Namespace).
 		Name(p.kubectl.Statement.Name).
@@ -25,13 +164,13 @@ func (p *pod) ResourceUsage() *ResourceUsageResult {
 		Get(&inst).Error
 	if err != nil {
 		klog.V(6).Infof("Get ResourceUsage in pod/%s  error %v\n", p.kubectl.Statement.Name, err.Error())
-		return nil
+		return nil, err
 	}
 
 	nodeName := inst.Spec.NodeName
 	if nodeName == "" {
 		klog.V(6).Infof("Get Pod ResourceUsage in pod/%s  error %v\n", p.kubectl.Statement.Name, "nodeName is empty")
-		return nil
+		return nil, fmt.Errorf("nodeName is empty")
 	}
 	var n *v1.Node
 	err = p.kubectl.newInstance().WithContext(p.kubectl.Statement.Context).Resource(&v1.Node{}).
@@ -39,12 +178,12 @@ func (p *pod) ResourceUsage() *ResourceUsageResult {
 		Name(nodeName).Get(&n).Error
 	if err != nil {
 		klog.V(6).Infof("Get Pod ResourceUsage in node/%s  error %v\n", nodeName, err.Error())
-		return nil
+		return nil, err
 	}
 
 	req, limit := resourcehelper.PodRequestsAndLimits(inst)
 	if req == nil || limit == nil {
-		return nil
+		return nil, fmt.Errorf("failed to get pod requests and limits")
 	}
 	allocatable := n.Status.Capacity
 	if len(n.Status.Allocatable) > 0 {
@@ -52,39 +191,51 @@ func (p *pod) ResourceUsage() *ResourceUsageResult {
 	}
 
 	klog.V(8).Infof("allocatable=:\n%s", utils.ToJSON(allocatable))
+
 	cpuReq, cpuLimit, memoryReq, memoryLimit := req[v1.ResourceCPU], limit[v1.ResourceCPU], req[v1.ResourceMemory], limit[v1.ResourceMemory]
+	cpuRealtime, memoryRealtime := realtimeMetrics[v1.ResourceCPU], realtimeMetrics[v1.ResourceMemory]
 	fractionCpuReq := float64(cpuReq.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
 	fractionCpuLimit := float64(cpuLimit.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+	fractionCpuRealtime := float64(cpuRealtime.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+
 	fractionMemoryReq := float64(memoryReq.Value()) / float64(allocatable.Memory().Value()) * 100
 	fractionMemoryLimit := float64(memoryLimit.Value()) / float64(allocatable.Memory().Value()) * 100
+	fractionMemoryRealtime := float64(memoryRealtime.Value()) / float64(allocatable.Memory().Value()) * 100
 
 	usageFractions := map[v1.ResourceName]ResourceUsageFraction{
 		v1.ResourceCPU: {
-			RequestFraction: fractionCpuReq,
-			LimitFraction:   fractionCpuLimit,
+			RequestFraction:  fractionCpuReq,
+			LimitFraction:    fractionCpuLimit,
+			RealtimeFraction: fractionCpuRealtime,
 		},
 		v1.ResourceMemory: {
-			RequestFraction: fractionMemoryReq,
-			LimitFraction:   fractionMemoryLimit,
+			RequestFraction:  fractionMemoryReq,
+			LimitFraction:    fractionMemoryLimit,
+			RealtimeFraction: fractionMemoryRealtime,
 		},
 	}
 
 	klog.V(6).Infof("%s\t%s\t\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\n", inst.Namespace, inst.Name,
 		cpuReq.String(), int64(fractionCpuReq), cpuLimit.String(), int64(fractionCpuLimit),
 		memoryReq.String(), int64(fractionMemoryReq), memoryLimit.String(), int64(fractionMemoryLimit))
+
 	return &ResourceUsageResult{
 		Requests:       req,
 		Limits:         limit,
+		Realtime:       realtimeMetrics,
 		Allocatable:    allocatable,
 		UsageFractions: usageFractions,
-	}
+	}, nil
 }
-func (p *pod) ResourceUsageTable() []*ResourceUsageRow {
-	usage := p.ResourceUsage()
+func (p *pod) ResourceUsageTable() ([]*ResourceUsageRow, error) {
+	usage, err := p.ResourceUsage()
+	if err != nil {
+		return nil, err
+	}
 	data, err := convertToTableData(usage)
 	if err != nil {
 		klog.V(6).Infof("convertToTableData error %v\n", err.Error())
-		return make([]*ResourceUsageRow, 0)
+		return nil, err
 	}
-	return data
+	return data, nil
 }

--- a/kom/struct.go
+++ b/kom/struct.go
@@ -10,27 +10,31 @@ import (
 
 // ResourceUsageFraction 定义单种资源的使用占比
 type ResourceUsageFraction struct {
-	RequestFraction float64 `json:"requestFraction"` // 请求使用占比（百分比）占总可分配值的比例
-	LimitFraction   float64 `json:"limitFraction"`   // 限制使用占比（百分比）占总可分配值的比例
+	RequestFraction  float64 `json:"requestFraction"`  // 请求使用占比（百分比）占总可分配值的比例
+	LimitFraction    float64 `json:"limitFraction"`    // 限制使用占比（百分比）占总可分配值的比例
+	RealtimeFraction float64 `json:"realtimeFraction"` // 实时指标显示的占比（百分比）占总可分配值的比例
 }
 
 // ResourceUsageResult 定义资源使用情况的结构体
 // 存放Pod、Node 的资源使用情况
 type ResourceUsageResult struct {
-	Requests       map[corev1.ResourceName]resource.Quantity     `json:"requests"`       // 请求用量
-	Limits         map[corev1.ResourceName]resource.Quantity     `json:"limits"`         // 限制用量
+	Requests       map[corev1.ResourceName]resource.Quantity     `json:"requests"` // 请求用量
+	Limits         map[corev1.ResourceName]resource.Quantity     `json:"limits"`   // 限制用量
+	Realtime       map[corev1.ResourceName]resource.Quantity     `json:"realtime"`
 	Allocatable    map[corev1.ResourceName]resource.Quantity     `json:"allocatable"`    // 节点可分配的实时值
 	UsageFractions map[corev1.ResourceName]ResourceUsageFraction `json:"usageFractions"` // 使用占比
 }
 
 // ResourceUsageRow 临时结构体，用于存储每一行数据
 type ResourceUsageRow struct {
-	ResourceType    string `json:"resourceType"`
-	Total           string `json:"total"`
-	Request         string `json:"request"`
-	RequestFraction string `json:"requestFraction"`
-	Limit           string `json:"limit"`
-	LimitFraction   string `json:"limitFraction"`
+	ResourceType     string `json:"resourceType"`
+	Total            string `json:"total"`
+	Request          string `json:"request"`
+	RequestFraction  string `json:"requestFraction"`
+	Limit            string `json:"limit"`
+	LimitFraction    string `json:"limitFraction"`
+	Realtime         string `json:"realtime"`
+	RealtimeFraction string `json:"realtimeFraction"`
 }
 
 func convertToTableData(result *ResourceUsageResult) ([]*ResourceUsageRow, error) {
@@ -45,13 +49,16 @@ func convertToTableData(result *ResourceUsageResult) ([]*ResourceUsageRow, error
 		alc := result.Allocatable[resourceType]
 		req := result.Requests[resourceType]
 		lit := result.Limits[resourceType]
+		realtime := result.Realtime[resourceType]
 		row := &ResourceUsageRow{
-			ResourceType:    string(resourceType),
-			Total:           utils.FormatResource(alc),
-			Request:         utils.FormatResource(req),
-			RequestFraction: fmt.Sprintf("%.2f", result.UsageFractions[resourceType].RequestFraction),
-			Limit:           utils.FormatResource(lit),
-			LimitFraction:   fmt.Sprintf("%.2f", result.UsageFractions[resourceType].LimitFraction),
+			ResourceType:     string(resourceType),
+			Total:            utils.FormatResource(alc),
+			Realtime:         utils.FormatResource(realtime),
+			RealtimeFraction: fmt.Sprintf("%.2f", result.UsageFractions[resourceType].RealtimeFraction),
+			Request:          utils.FormatResource(req),
+			RequestFraction:  fmt.Sprintf("%.2f", result.UsageFractions[resourceType].RequestFraction),
+			Limit:            utils.FormatResource(lit),
+			LimitFraction:    fmt.Sprintf("%.2f", result.UsageFractions[resourceType].LimitFraction),
 		}
 		// 将行加入表格数据
 		tableData = append(tableData, row)


### PR DESCRIPTION
重构了节点和Pod的资源使用计算逻辑，增加了对实时资源使用指标的支持。现在可以获取CPU和内存的实时使用情况，并在资源使用结果中展示实时使用占比。同时，将相关代码从`ctl_node.go`和`ctl_pod.go`中提取到独立的文件`ctl_node_usage.go`和`ctl_pod_usage.go`中，以提高代码的可维护性。