### PR TITLE
fix(mcp): 修复资源元数据解析过程中的认证信息处理- 引入新的 context (newCtx) 用于存储认证信息- 添加默认值处…

### DIFF
--- a/mcp/metadata/utils.go
+++ b/mcp/metadata/utils.go
@@ -57,13 +57,22 @@ func IsNamespaced(resourceType string) bool {
 
 // ParseFromRequest 从请求中解析资源元数据
 func ParseFromRequest(ctx context.Context, request mcp.CallToolRequest, serverConfig *ServerConfig) (context.Context, *ResourceMetadata, error) {
+	newCtx := context.Background()
 	if serverConfig != nil {
-		if authVal, ok := ctx.Value(serverConfig.AuthKey).(string); ok {
-			ctx = context.WithValue(ctx, serverConfig.AuthKey, authVal)
+		authVal, ok := ctx.Value(serverConfig.AuthKey).(string)
+		if !ok {
+			authVal = "defaultAuthVal"
 		}
-		if authRoleVal, ok := ctx.Value(serverConfig.AuthRoleKey).(string); ok {
-			ctx = context.WithValue(ctx, serverConfig.AuthRoleKey, authRoleVal)
+
+		authRoleVal, ok := ctx.Value(serverConfig.AuthRoleKey).(string)
+		if !ok {
+			authRoleVal = "defaultRole"
 		}
+
+		newCtx = context.WithValue(ctx, serverConfig.AuthKey, authVal)
+		newCtx = context.WithValue(newCtx, serverConfig.AuthRoleKey, authRoleVal)
+
+		// 用 newCtx 传递下去
 	}
 
 	// 验证必要参数
@@ -108,7 +117,7 @@ func ParseFromRequest(ctx context.Context, request mcp.CallToolRequest, serverCo
 		kind = getStringParam(request, "kind", "")
 	}
 
-	return ctx, &ResourceMetadata{
+	return newCtx, &ResourceMetadata{
 		Cluster:   cluster,
 		Namespace: namespace,
 		Name:      name,


### PR DESCRIPTION
…理，当认证信息不存在时使用默认值

- 优化认证信息的获取和存储逻辑
- 更新函数返回值，使用新的 context 传递认证信息