### PR TITLE
feat: 添加Gateway API支持检查功能并优化CRD列表获取

### DIFF
--- a/example/crd_test.go
+++ b/example/crd_test.go
@@ -1,0 +1,16 @@
+package example
+
+import (
+	"testing"
+
+	"github.com/weibaohui/kom/kom"
+)
+
+func TestCRDList(t *testing.T) {
+	list := kom.DefaultCluster().Status().CRDList()
+	for _, crd := range list {
+		t.Logf("%s", crd.GetName())
+	}
+	supported := kom.DefaultCluster().Status().IsGatewayAPISupported()
+	t.Logf("gateway api supported: %v", supported)
+}

--- a/kom/status.go
+++ b/kom/status.go
@@ -25,8 +25,7 @@ func (s *status) APIResources() []*metav1.APIResource {
 	return cluster.apiResources
 }
 func (s *status) CRDList() []*unstructured.Unstructured {
-	cluster := s.kubectl.parentCluster()
-	return cluster.crdList
+	return s.kubectl.initializeCRDList(time.Minute * 10)
 }
 func (s *status) Docs() *doc.Docs {
 	cluster := s.kubectl.parentCluster()
@@ -43,6 +42,17 @@ func (s *status) DescriberMap() map[schema.GroupKind]describe.ResourceDescriber 
 func (s *status) OpenAPISchema() *openapi_v2.Document {
 	cluster := s.kubectl.parentCluster()
 	return cluster.openAPISchema
+}
+
+func (s *status) IsGatewayAPISupported() bool {
+	list := s.CRDList()
+	name := "gateways.gateway.networking.k8s.io"
+	for _, crd := range list {
+		if crd.GetName() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // 获取版本信息

--- a/kom/tools.go
+++ b/kom/tools.go
@@ -222,7 +222,7 @@ func (u *tools) FindGVKByTableNameInApiResources(tableName string) *schema.Group
 // FindGVKByTableNameInCRDList 从CRD列表中找到对应的表名的GVK
 func (u *tools) FindGVKByTableNameInCRDList(tableName string) *schema.GroupVersionKind {
 
-	for _, crd := range u.kubectl.parentCluster().crdList {
+	for _, crd := range u.kubectl.Status().CRDList() {
 		// 从 CRD 对象中获取 "spec" 下的 names 字段
 		specNames, found, err := unstructured.NestedMap(crd.Object, "spec", "names")
 		if err != nil || !found {


### PR DESCRIPTION
在`status.go`中添加了`IsGatewayAPISupported`方法，用于检查Gateway API是否支持。同时优化了`CRDList`方法，改为调用`initializeCRDList`以获取CRD列表，并设置了10分钟的缓存时间。在`tools.go`中更新了`FindGVKByTableNameInCRDList`方法，使用`Status().CRDList()`获取CRD列表。新增了`crd_test.go`文件，包含对`CRDList`和`IsGatewayAPISupported`方法的测试。