### PR TITLE
refactor: 使用更合适的日志和错误输出函数

### DIFF
--- a/example/cross_ns_test.go
+++ b/example/cross_ns_test.go
@@ -54,7 +54,7 @@ spec:
 	if err != nil {
 		t.Errorf("List Error %v\n", err)
 	}
-	t.Logf(fmt.Sprintf("pod count %d", len(items)))
+	t.Log(fmt.Sprintf("pod count %d", len(items)))
 	for _, node := range items {
 		t.Logf("pde name %s/%s\n", node.Namespace, node.Name)
 	}

--- a/example/doc_test.go
+++ b/example/doc_test.go
@@ -10,5 +10,5 @@ import (
 func TestDoc(t *testing.T) {
 	docs := kom.DefaultCluster().Status().Docs()
 	pc := docs.FetchByGVK("v1", "Pod")
-	t.Logf(utils.ToJSON(pc))
+	t.Log(utils.ToJSON(pc))
 }

--- a/example/example.go
+++ b/example/example.go
@@ -98,7 +98,7 @@ func ALLNodeUsageExample() {
 		usage, err := kom.DefaultCluster().Resource(&corev1.Node{}).
 			Name(nodeName).WithCache(5 * time.Second).Ctl().Node().ResourceUsageTable()
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Printf("%s", err.Error())
 			return
 		}
 		fmt.Printf("Node Usage %s\n", utils.ToJSON(usage))

--- a/example/node_usage_test.go
+++ b/example/node_usage_test.go
@@ -30,7 +30,7 @@ func TestNodeResourceUsageTable(t *testing.T) {
 	usage, err := kom.DefaultCluster().Resource(&corev1.Node{}).
 		Name(nodeName).WithCache(5 * time.Second).Ctl().Node().ResourceUsageTable()
 	if err != nil {
-		fmt.Printf(err.Error())
+		fmt.Print(err.Error())
 		return
 	}
 	t.Logf("Node Usage %s\n", utils.ToJSON(usage))


### PR DESCRIPTION
将 `t.Logf` 和 `fmt.Printf` 替换为 `t.Log` 和 `fmt.Print`，以提高代码简洁性和可读性。这些更改不影响功能，但使代码更加一致和易于维护。