### PR TITLE
fix: 调整获取 pod 请求和限制的逻辑顺序

### DIFF
--- a/kom/ctl_pod_usage.go
+++ b/kom/ctl_pod_usage.go
@@ -49,6 +49,11 @@ func (p *pod) ResourceUsage() (*ResourceUsageResult, error) {
 		return nil, err
 	}
 
+	req, limit := resourcehelper.PodRequestsAndLimits(inst)
+	if req == nil || limit == nil {
+		return nil, fmt.Errorf("failed to get pod requests and limits")
+	}
+
 	nodeName := inst.Spec.NodeName
 	if nodeName == "" {
 		klog.V(6).Infof("Get Pod ResourceUsage in pod/%s  error %v\n", p.kubectl.Statement.Name, "nodeName is empty")
@@ -63,10 +68,6 @@ func (p *pod) ResourceUsage() (*ResourceUsageResult, error) {
 		return nil, err
 	}
 
-	req, limit := resourcehelper.PodRequestsAndLimits(inst)
-	if req == nil || limit == nil {
-		return nil, fmt.Errorf("failed to get pod requests and limits")
-	}
 	allocatable := n.Status.Capacity
 	if len(n.Status.Allocatable) > 0 {
 		allocatable = n.Status.Allocatable


### PR DESCRIPTION
在 `ResourceUsage` 函数中，将获取 pod 请求和限制的逻辑提前，以避免在后续操作中因未获取到请求和限制而导致的错误。这样可以确保在检查节点名称之前，先验证 pod 的请求和限制是否有效。