### PR TITLE
refactor: 统一JSON字段命名格式

### DIFF
--- a/kom/ctl_node_usage.go
+++ b/kom/ctl_node_usage.go
@@ -19,8 +19,8 @@ type NodeUsage struct {
 	Memory         string `json:"memory"`
 	CPUNano        int64  `json:"cpu_nano"`
 	MemoryByte     int64  `json:"memory_byte"`
-	CPUFraction    string `json:"cpuFraction"`
-	MemoryFraction string `json:"memoryFraction"`
+	CPUFraction    string `json:"cpu_fraction"`
+	MemoryFraction string `json:"memory_fraction"`
 }
 
 func (d *node) TotalRequestsAndLimits() (map[corev1.ResourceName]resource.Quantity, map[corev1.ResourceName]resource.Quantity) {


### PR DESCRIPTION
将`CPUFraction`和`MemoryFraction`字段的JSON标签从驼峰式改为下划线式，以保持与代码库中其他字段命名的一致性