### PR TITLE
fix(pod_exec_test): 修复命令执行错误处理

### DIFF
--- a/example/pod_exec_test.go
+++ b/example/pod_exec_test.go
@@ -123,11 +123,14 @@ func TestPodStreamExecWithOptions(t *testing.T) {
 		TerminalSizeQueue: sizeQueue, // 传递 TTY 尺寸管理队列
 	}
 
-	kom.DefaultCluster().Namespace("default").
-		Name("bash-runner-5bd4b4bdbb-qzgmx").
+	err := kom.DefaultCluster().Namespace("default").
+		Name("bash-runner-5bd4b4bdbb-wmjnb").
 		Ctl().Pod().
 		Command("/bin/sh", "-c", "TERM=xterm-256color; export TERM; [ -x /bin/bash ] && ([ -x /usr/bin/script ] && /usr/bin/script -q -c '/bin/bash' /dev/null || exec /bin/bash) || exec /bin/sh").
-		StreamExecuteWithOptions(opt)
+		StreamExecuteWithOptions(opt).Error
+	if err != nil {
+		klog.Errorf("Error executing command: %v", err)
+	}
 
 	waiter.Wait()
 }


### PR DESCRIPTION
在测试函数中增加错误处理，当命令执行失败时记录错误日志，以便更好地调试问题