### PR TITLE
refactor: 移除未使用的认证角色相关代码

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/duke-git/lancet/v2 v2.3.5
 	github.com/fatih/camelcase v1.0.0
 	github.com/google/gnostic-models v0.6.9
-	github.com/mark3labs/mcp-go v0.17.0
+	github.com/mark3labs/mcp-go v0.25.0
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
@@ -17,8 +17,6 @@ require (
 	k8s.io/kubectl v0.33.0
 	sigs.k8s.io/yaml v1.4.0
 )
-
-replace github.com/mark3labs/mcp-go => github.com/weibaohui/mcp-go v0.0.5
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mark3labs/mcp-go v0.25.0 h1:UUpcMT3L5hIhuDy7aifj4Bphw4Pfx1Rf8mzMXDe8RQw=
+github.com/mark3labs/mcp-go v0.25.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
@@ -131,8 +133,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/weibaohui/mcp-go v0.0.5 h1:uiHCF0vVtO99Cu3NIMOwE2+Rq5fCjAp4vUZmsC8oURY=
-github.com/weibaohui/mcp-go v0.0.5/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/main.go
+++ b/main.go
@@ -26,16 +26,10 @@ func main() {
 	// kom执行时，如果注册了callback，那么可以在callback中获取到ctx，从ctx上可以拿到注入的认证信息
 	// 有了认证信息，就可以在callback中，进行权限的逻辑控制了
 	authKey := "username"
-	authRoleKey := "role"
 	var ctxFn = func(ctx context.Context, r *http.Request) context.Context {
 		authKeyVal := r.Header.Get(authKey)
-		authRoleVal := r.Header.Get(authRoleKey)
-		authKeyVal = "admin"
-		authRoleVal = "admin-role"
 		klog.Infof("%s: %s", authKey, authKeyVal)
-		klog.Infof("%s: %s", authRoleKey, authRoleKey)
 		ctx = context.WithValue(ctx, authKey, authKeyVal)
-		ctx = context.WithValue(ctx, authRoleKey, authRoleVal)
 
 		return ctx
 	}
@@ -51,9 +45,8 @@ func main() {
 		SSEOption: []server.SSEOption{
 			server.WithSSEContextFunc(ctxFn),
 		},
-		AuthKey:     authKey,
-		AuthRoleKey: authRoleKey,
-		Mode:        metadata.MCPServerModeSSE, // 开启STDIO 或者 SSE
+		AuthKey: authKey,
+		Mode:    metadata.MCPServerModeSSE, // 开启STDIO 或者 SSE
 	}
 	mcp.RunMCPServerWithOption(&cfg)
 

--- a/mcp/metadata/type.go
+++ b/mcp/metadata/type.go
@@ -21,7 +21,6 @@ type ServerConfig struct {
 	SSEOption     []server.SSEOption
 	Metadata      map[string]string // 元数据
 	AuthKey       string            // 认证key
-	AuthRoleKey   string            // 认证key
 	Mode          MCPServerMode     // 运行模式 sse,stdio
 }
 type MCPServerMode string

--- a/mcp/metadata/utils.go
+++ b/mcp/metadata/utils.go
@@ -63,16 +63,7 @@ func ParseFromRequest(ctx context.Context, request mcp.CallToolRequest, serverCo
 		if !ok {
 			authVal = ""
 		}
-
-		authRoleVal, ok := ctx.Value(serverConfig.AuthRoleKey).(string)
-		if !ok {
-			authRoleVal = ""
-		}
-
 		newCtx = context.WithValue(ctx, serverConfig.AuthKey, authVal)
-		newCtx = context.WithValue(newCtx, serverConfig.AuthRoleKey, authRoleVal)
-
-		// 用 newCtx 传递下去
 	}
 
 	// 验证必要参数


### PR DESCRIPTION
移除 `AuthRoleKey` 字段及其相关逻辑，简化代码结构。同时更新 `mcp-go` 依赖至 v0.25.0