### PR TITLE
refactor(port-forward): 将 PortForward 方法从 Kubectl 移到 Pod 并添加容器名称支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ fmt.Printf("execResult: %s", execResult)
 err := kom.DefaultCluster().Resource(&v1.Pod{}).
 		Namespace("default").
 		Name("nginx-deployment-f576985cc-7czqr").
+    Ctl().Pod().
+		ContainerName("nginx").
 		PortForward("20088", "80", stopCh).Error
 // 监听0.0.0.0上的20088端口，转发到Pod的80端口
 ```

--- a/callbacks/port_forward.go
+++ b/callbacks/port_forward.go
@@ -19,6 +19,7 @@ func PortForward(k *kom.Kubectl) error {
 	stopCh := stmt.PortForwardStopCh
 	podPort := stmt.PortForwardPodPort
 	localPort := stmt.PortForwardLocalPort
+	containerName := stmt.ContainerName
 
 	// 检查端口，必须设置
 	if localPort == "" || podPort == "" {
@@ -33,8 +34,9 @@ func PortForward(k *kom.Kubectl) error {
 		Namespace(ns).
 		Name(name).
 		Resource("pods").
-		SubResource("portforward")
-	// 启动 port-forward
+		SubResource("portforward").
+		Param("container", containerName)
+	 
 	readyChan := make(chan struct{})
 
 	// 创建 PortForward 请求

--- a/example/port_forward_test.go
+++ b/example/port_forward_test.go
@@ -18,7 +18,10 @@ func TestPortForward(t *testing.T) {
 	err := kom.DefaultCluster().Resource(&v1.Pod{}).
 		Namespace("default").
 		Name("nginx-deployment-f576985cc-7czqr").
+		Ctl().Pod().
+		ContainerName("nginx").
 		PortForward("20088", "80", stopCh).Error
+
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/kom/ctl_pod.go
+++ b/kom/ctl_pod.go
@@ -68,3 +68,11 @@ func (p *pod) GetLogs(requestPtr interface{}, opt *v1.PodLogOptions) *pod {
 	p.Error = tx.Error
 	return p
 }
+func (p *pod) PortForward(localPort, podPort string, stopCh chan struct{}) *Kubectl {
+	tx := p.kubectl.getInstance()
+	tx.Statement.PortForwardLocalPort = localPort
+	tx.Statement.PortForwardPodPort = podPort
+	tx.Statement.PortForwardStopCh = stopCh
+	tx.Error = tx.Callback().PortForward().Execute(tx)
+	return tx
+}

--- a/kom/sql.go
+++ b/kom/sql.go
@@ -181,14 +181,6 @@ func (k *Kubectl) List(dest interface{}, opt ...metav1.ListOptions) *Kubectl {
 	tx.Error = tx.Callback().List().Execute(tx)
 	return tx
 }
-func (k *Kubectl) PortForward(localPort, podPort string, stopCh chan struct{}) *Kubectl {
-	tx := k.getInstance()
-	tx.Statement.PortForwardLocalPort = localPort
-	tx.Statement.PortForwardPodPort = podPort
-	tx.Statement.PortForwardStopCh = stopCh
-	tx.Error = tx.Callback().PortForward().Execute(tx)
-	return tx
-}
 
 // 合并两个选择器，使用逗号分隔
 func mergeSelectors(selector1, selector2 string) string {


### PR DESCRIPTION
将 PortForward 方法从 Kubectl 结构体迁移到 Pod 结构体，以更好地封装功能。同时，在 PortForward 请求中添加容器名称参数，以支持多容器场景的端口转发。