### PR TITLE
refactor(callbacks): 将日志级别从Info调整为Verbose

### DIFF
--- a/callbacks/callbacks.go
+++ b/callbacks/callbacks.go
@@ -6,9 +6,9 @@ import (
 )
 
 func RegisterInit() {
-	klog.Infof("RegisterInit")
+	klog.V(4).Infof("RegisterInit")
 	kom.Clusters().SetRegisterCallbackFunc(RegisterDefaultCallbacks)
-	klog.Infof("Register RegisterDefaultCallbacks func  to clusters")
+	klog.V(4).Infof("Register RegisterDefaultCallbacks func  to clusters")
 }
 func init() {
 	RegisterInit()


### PR DESCRIPTION
将RegisterInit函数中的日志输出从klog.Infof调整为klog.V(4).Infof，以减少生产环境中的日志输出量，提升日志的可管理性