### PR TITLE
perf: 在移除集群后触发GC以释放内存

### DIFF
--- a/kom/cluster.go
+++ b/kom/cluster.go
@@ -2,6 +2,7 @@ package kom
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -227,6 +228,7 @@ func (c *ClusterInstances) RemoveClusterById(id string) {
 		cluster.openAPISchema = nil
 	}
 	c.clusters.Delete(id)
+	go runtime.GC()
 }
 
 // AllClusters 返回所有集群实例


### PR DESCRIPTION
在RemoveClusterById方法中调用runtime.GC()主动触发垃圾回收，及时释放被删除集群占用的内存资源