### PR TITLE
feat(callbacks): 添加文档缓存功能

### DIFF
--- a/example/doc_test.go
+++ b/example/doc_test.go
@@ -2,6 +2,7 @@ package example
 
 import (
 	"testing"
+	"time"
 
 	"github.com/weibaohui/kom/kom"
 	v1 "k8s.io/api/apps/v1"
@@ -14,7 +15,13 @@ func TestGetDoc(t *testing.T) {
 	field = "spec.template.spec.containers.name"
 	field = "spec.template.spec.containers.imagePullPolicy"
 	field = "spec.template.spec.containers.livenessProbe.successThreshold"
-	err := kom.DefaultCluster().
+	err := kom.DefaultCluster().WithCache(time.Second * 50).
+		Resource(&item).DocField(field).Doc(&docResult).Error
+	if err != nil {
+		t.Errorf("Get Deployment Doc [%s]error :%v", field, err)
+	}
+	t.Logf("Get Deployment Doc [%s] :%s", field, string(docResult))
+	err = kom.DefaultCluster().WithCache(time.Second * 50).
 		Resource(&item).DocField(field).Doc(&docResult).Error
 	if err != nil {
 		t.Errorf("Get Deployment Doc [%s]error :%v", field, err)

--- a/kom/doc/doc_field.go
+++ b/kom/doc/doc_field.go
@@ -6,6 +6,7 @@ import (
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 )
 
 type DocField struct {
@@ -15,6 +16,7 @@ type DocField struct {
 }
 
 func (k *DocField) GetApiDocV2(field string) string {
+	klog.V(8).Infof("GetApiDocV2 %s", field)
 	startPoint := ""
 	// the path must be formated like "path1.path2.path3"
 	paths := strings.Split(field, ".")


### PR DESCRIPTION
- 在 callbacks/doc.go 中实现文档缓存逻辑
- 在 kom/doc/doc_field.go 中添加 GetApiDocV2 函数的日志记录
- 更新 example/doc_test.go，增加缓存功能的测试用例