### PR TITLE
refactor(aws): 优化EKSAuthConfig参数为指针类型

### DIFF
--- a/kom/aws/generator.go
+++ b/kom/aws/generator.go
@@ -30,7 +30,7 @@ func NewKubeconfigGenerator() *KubeconfigGenerator {
 }
 
 // GenerateFromAWS 通过AWS CLI生成kubeconfig
-func (kg *KubeconfigGenerator) GenerateFromAWS(config EKSAuthConfig) (string, error) {
+func (kg *KubeconfigGenerator) GenerateFromAWS(config *EKSAuthConfig) (string, error) {
 	if err := kg.validateConfig(config); err != nil {
 		return "", err
 	}
@@ -70,7 +70,7 @@ func (kg *KubeconfigGenerator) GenerateFromAWS(config EKSAuthConfig) (string, er
 }
 
 // validateConfig 验证配置
-func (kg *KubeconfigGenerator) validateConfig(config EKSAuthConfig) error {
+func (kg *KubeconfigGenerator) validateConfig(config *EKSAuthConfig) error {
 	if config.AccessKey == "" {
 		return NewEKSAuthError(ErrorTypeInvalidCredentials, "AccessKey is required", nil)
 	}
@@ -112,7 +112,7 @@ func generateRandomString(length int) (string, error) {
 }
 
 // buildEnvVariables 构建环境变量
-func (kg *KubeconfigGenerator) buildEnvVariables(config EKSAuthConfig, kubeconfigPath string) []string {
+func (kg *KubeconfigGenerator) buildEnvVariables(config *EKSAuthConfig, kubeconfigPath string) []string {
 	envVars := []string{
 		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", config.AccessKey),
 		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", config.SecretAccessKey),
@@ -131,7 +131,7 @@ func (kg *KubeconfigGenerator) buildEnvVariables(config EKSAuthConfig, kubeconfi
 }
 
 // executeAWSCommandWithEnv 执行AWS CLI命令
-func (kg *KubeconfigGenerator) executeAWSCommandWithEnv(config EKSAuthConfig, envVars []string) error {
+func (kg *KubeconfigGenerator) executeAWSCommandWithEnv(config *EKSAuthConfig, envVars []string) error {
 	// 构建AWS CLI命令
 	args := []string{
 		"eks",

--- a/kom/cluster.go
+++ b/kom/cluster.go
@@ -381,9 +381,11 @@ func NewAWSAuthProvider() *aws.AuthProvider {
 
 // RegisterAWSCluster 注册EKS集群
 func (c *ClusterInstances) RegisterAWSCluster(config aws.EKSAuthConfig) (*Kubectl, error) {
-
 	// 生成集群ID
 	clusterID := fmt.Sprintf("%s-%s", config.Region, config.ClusterName)
+	return c.RegisterAWSClusterWithID(config, clusterID)
+}
+func (c *ClusterInstances) RegisterAWSClusterWithID(config aws.EKSAuthConfig, clusterID string) (*Kubectl, error) {
 
 	var cluster *ClusterInst
 	// 检查是否已存在


### PR DESCRIPTION
- 将KubeconfigGenerator中相关方法的EKSAuthConfig参数改为指针类型，避免结构体拷贝
- 修改RegisterAWSCluster逻辑，新增RegisterAWSClusterWithID支持自定义集群ID
- 调整集群注册代码结构，提升代码复用性和可维护性